### PR TITLE
解决消息内容过长导致写入异常的问题

### DIFF
--- a/models/messaging.py
+++ b/models/messaging.py
@@ -46,7 +46,7 @@ class Message(BaseMixin, db.Model):
     group_id = db.Column(db.String(20), default=0, index=True)
     sender_id = db.Column(db.String(20), index=True)
     receiver_id = db.Column(db.String(20), index=True)
-    content = db.Column(db.String(255))
+    content = db.Column(db.String(1024))
     receive_time = db.Column(db.DateTime)
     type = db.Column(db.SmallInteger)
     url = db.Column(db.String(512), default='')


### PR DESCRIPTION
消息长度由255改为1024