### PR TITLE
解决微信用户签名中含有emoji表情字段过长导致记录插入失败问题

### DIFF
--- a/models/core.py
+++ b/models/core.py
@@ -45,7 +45,7 @@ class User(CoreMixin, db.Model):
     id = db.Column(db.String(20), primary_key=True)  # puid
     sex = db.Column(db.SmallInteger, default=2)
     nick_name = db.Column(db.String(60), index=True)
-    signature = db.Column(db.String(255), default='')
+    signature = db.Column(db.String(512), default='')
     province = db.Column(db.String(20), default='')
     city = db.Column(db.String(20), default='')
     groups =db.relationship('Group', secondary=group_relationship,


### PR DESCRIPTION
User的signature字段长度由255改为512